### PR TITLE
Change cancel and finish threshold to 1 from 2

### DIFF
--- a/bookied/triggers/cancel.py
+++ b/bookied/triggers/cancel.py
@@ -21,7 +21,7 @@ class CancelTrigger(Trigger):
             .. alert:: This is temporary set to be ``2`` until we have an
                 easier way to identify how many data proxies send data to us
         """
-        return 2
+        return 1
 
     def testConditions(self, *args, **kwargs):
         """ The test conditions for canceling the event are as this:

--- a/bookied/triggers/finish.py
+++ b/bookied/triggers/finish.py
@@ -27,7 +27,7 @@ class FinishTrigger(Trigger):
             .. alert:: This is temporary set to be ``2`` until we have an
                 easier way to identify how many data proxies send data to us
         """
-        return 2
+        return 1
 
     def testConditions(self, *args, **kwargs):
         """ The test conditions for finishing the event are as this:


### PR DESCRIPTION
Addressing issue BOS-205
To have smooth transition, update number of DP's approval to 1 from 2 for `cancel and finish` incidents.
Important states like `create, result` still need approval from minimum of two DP's.